### PR TITLE
Fix list equality for lists of unequal length

### DIFF
--- a/std/List/Church.bruijn
+++ b/std/List/Church.bruijn
@@ -415,11 +415,17 @@ in? …∘… any? ⧗ (a → a → Boolean) → a → (List a) → Boolean
 :test (in? …=?… (+0) ((+1) : ((+2) : {}(+3)))) (false)
 
 # returns true if all elements of one list are equal to corresponding elements of other list
-eq? ⋀?‣ ∘∘∘ zip-with ⧗ (a → a → Boolean) → (List a) → Boolean
+eq? z [[[[rec]]]] ⧗ (a → a → Boolean) → (List a) → (List a) → Boolean
+	rec ∅?1 ∅?0 (∅?0 false case-both-nonempty)
+		case-both-nonempty (2 ^1 ^0) ⋀? (3 2 ~1 ~0)
 
 :test (eq? …=?… ((+1) : {}(+2)) ((+1) : {}(+2))) (true)
 :test (eq? …=?… ((+1) : {}(+2)) ((+2) : {}(+2))) (false)
 :test (eq? …=?… empty empty) (true)
+:test (eq? …=?… ((+1) : {}(+2)) {}(+1)) (false)
+:test (eq? …=?… {}(+1) ((+1) : {}(+2))) (false)
+:test (eq? …=?… empty {}(+1)) (false)
+:test (eq? …=?… {}(+1) empty) (false)
 
 # returns eq, lt, gt depending on comparison of two lists and comparison function
 compare-case' z [[[[[[[rec]]]]]]] ⧗ Compare → a → b → c → (List a) → (List a) → d

--- a/std/String.bruijn
+++ b/std/String.bruijn
@@ -14,6 +14,11 @@ eq? eq? B.eq? ⧗ String → String → Boolean
 
 :test ("ab" =? "ab") (true)
 :test ("ab" =? "aa") (false)
+:test (empty =? empty) (true)
+:test ("ab" =? "a") (false)
+:test ("a" =? "ab") (false)
+:test (empty =? "a") (false)
+:test ("a" =? empty) (false)
 
 # prefix for comparing functions
 ?‣ &eq?


### PR DESCRIPTION
While trying out Bruijn on some early day Advent of Code puzzles this year (Bruijn is a very cool project BTW!), I noticed an issue with list/string equality on inputs of unequal length.